### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-docs",
-  "version": "6.4.0",
+  "version": "6.5.1",
   "description": "Documentation for the @sharkyfi/client package",
   "repository": "https://github.com/SharkyFi/client",
   "license": "MIT",


### PR DESCRIPTION
I see our version on NPM is already 6.5.0 but on git we use 6.2.0 - initially bumped this to 6.3.0 but will align with NPM and include the patch: 6.5.1